### PR TITLE
Enabled used of prebuilt `shaderc` binaries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,5 +8,7 @@ set(WITH_IMGUI   OFF)
 set(WITH_MESHOPT OFF)
 set(WITH_STB     OFF)
 
+option(WITH_PREBUILT_SHADERC "Attempt to download prebuilt BGFX shader compiler." ON)
+
 add_subdirectory(third_party)
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Starter Template
+A graphics application starter package.
 
 ## Libraries
 
@@ -9,11 +10,16 @@
 * [GLFW](https://github.com/glfw/glfw/tree/dd8a678a66f1967372e5a5e3deac41ebf65ee127)
 
 ### Optional
-* [Dear ImGui](https://github.com/ocornut/imgui/tree/69beaa1d0b7fc8f4b448dcf1780b08cfc959da65)
-* [{fmt}](https://github.com/fmtlib/fmt/commit/80f8d34427d40ec5e7ce3b10ededc46bd4bd5759)
-* [GLEQ](https://github.com/glfw/gleq/tree/4dd5070341fa17856d06a38f948a100df2fc34cd)
-* [meshoptimizer](https://github.com/zeux/meshoptimizer/tree/c4cfc3581f37ae70fa274bef37584a588ae266ab)
-* [stb](https://github.com/nothings/stb/commit/8b5f1f37b5b75829fc72d38e7b5d4bcbf8a26d55)
-
 To enable an optional library, go to [CMakeLists.txt](CMakeLists.txt) and set
 the applicable `WITH_...` variable to `ON`.
+
+| Library | CMake Option |
+| ------------- | ------------- |
+| [Dear ImGui](https://github.com/ocornut/imgui/tree/69beaa1d0b7fc8f4b448dcf1780b08cfc959da65) | `WITH_IMGUI` |
+| [{fmt}](https://github.com/fmtlib/fmt/commit/80f8d34427d40ec5e7ce3b10ededc46bd4bd5759) | `WITH_FMT` |
+| [GLEQ](https://github.com/glfw/gleq/tree/4dd5070341fa17856d06a38f948a100df2fc34cd) | `WITH_GLEQ` |
+| [meshoptimizer](https://github.com/zeux/meshoptimizer/tree/c4cfc3581f37ae70fa274bef37584a588ae266ab) | `WITH_MESHOPT` |
+| [stb](https://github.com/nothings/stb/commit/8b5f1f37b5b75829fc72d38e7b5d4bcbf8a26d55) | `WITH_STB` |
+
+#### shaderc
+By default, BGFX's `shaderc` compiler is built from source. This can take a relatively long time. Use `WITH_PREBUILT_SHADERC` to attempt to fetch a prebuilt version (might not be available for your platform).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 ### Optional
 * [Dear ImGui](https://github.com/ocornut/imgui/tree/69beaa1d0b7fc8f4b448dcf1780b08cfc959da65)
+* [{fmt}](https://github.com/fmtlib/fmt/commit/80f8d34427d40ec5e7ce3b10ededc46bd4bd5759)
 * [GLEQ](https://github.com/glfw/gleq/tree/4dd5070341fa17856d06a38f948a100df2fc34cd)
 * [meshoptimizer](https://github.com/zeux/meshoptimizer/tree/c4cfc3581f37ae70fa274bef37584a588ae266ab)
 * [stb](https://github.com/nothings/stb/commit/8b5f1f37b5b75829fc72d38e7b5d4bcbf8a26d55)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -9,10 +9,12 @@ include(FetchContent)
 # BGFX
 # ------------------------------------------------------------------------------
 
+set(BGFX_GIT_TAG e87f08b1e50af8ad416e34fe7365aa5fb6fe5e37)
+
 FetchContent_Declare(
     bgfx
     GIT_REPOSITORY https://github.com/bkaradzic/bgfx.git
-    GIT_TAG        e87f08b1e50af8ad416e34fe7365aa5fb6fe5e37
+    GIT_TAG        ${BGFX_GIT_TAG}
 )
 
 FetchContent_Populate(bgfx)

--- a/third_party/cmake/shaderc.cmake
+++ b/third_party/cmake/shaderc.cmake
@@ -1,6 +1,39 @@
 set(SHADERC_RELATIVE_TOOL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../tools/shaderc")
 get_filename_component(SHADERC_TOOL_DIR ${SHADERC_RELATIVE_TOOL_DIR} ABSOLUTE)
 
+set(PREBUILT_SHADERC_AVAILABLE OFF)
+
+if(WITH_PREBUILT_SHADERC)
+    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR
+        CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "AMD64" OR
+        CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
+        set(PREBUILT_SHADERC_BRANCH "x64")
+    else()
+        set(PREBUILT_SHADERC_BRANCH "unsupported")
+    endif()
+
+    if(APPLE)
+        string(PREPEND PREBUILT_SHADERC_BRANCH "macos-")
+    elseif(WIN32)
+        string(PREPEND PREBUILT_SHADERC_BRANCH "windows-")
+    endif()
+
+    if(PREBUILT_SHADERC_BRANCH MATCHES "^(macos-x64|windows-x64)$")
+        message(STATUS "Prebuilt shaderc binary available.")
+        set(PREBUILT_SHADERC_AVAILABLE ON)
+
+        FetchContent_Declare(
+            shaderc_prebuilt
+            GIT_REPOSITORY https://github.com/fiserj/starter-tools.git
+            GIT_TAG        "shaderc-${PREBUILT_SHADERC_BRANCH}-${BGFX_GIT_TAG}"
+        )
+
+        FetchContent_Populate(shaderc_prebuilt)
+    else()
+        message(WARNING "Prebuilt shaderc binary unavailable; will be built from source.")
+    endif()
+endif() # WITH_PREBUILT_SHADERC
+
 if(APPLE)
     set(SHADERC_TOOL_BUILD_SCRIPT "${SHADERC_TOOL_DIR}/osx/build.sh")
     set(SHADERC_TOOL_OUTPUT_BINARY "${SHADERC_TOOL_DIR}/osx/shaderc")
@@ -8,16 +41,27 @@ elseif(WIN32)
     set(SHADERC_TOOL_BUILD_SCRIPT "${SHADERC_TOOL_DIR}/windows/build.bat")
     set(SHADERC_TOOL_OUTPUT_BINARY "${SHADERC_TOOL_DIR}/windows/shaderc.exe")
 else()
-    message(FATAL_ERROR "Script compiling shaderc binary does not yet exist for this platform.")
+    if(NOT PREBUILT_SHADERC_AVAILABLE)
+        message(FATAL_ERROR "Script compiling shaderc binary does not yet exist for this platform.")
+    endif()
 endif()
 
 get_filename_component(SHADERC_TOOL_WORKING_DIR ${SHADERC_TOOL_BUILD_SCRIPT} DIRECTORY)
 
-add_custom_command(
-    OUTPUT ${SHADERC_TOOL_OUTPUT_BINARY}
-    COMMAND ${SHADERC_TOOL_BUILD_SCRIPT}
-    WORKING_DIRECTORY ${SHADERC_TOOL_WORKING_DIR}
-)
+if(PREBUILT_SHADERC_AVAILABLE)
+    get_filename_component(SHADERC_TOOL_NAME ${SHADERC_TOOL_OUTPUT_BINARY} NAME)
+
+    add_custom_command(
+        OUTPUT ${SHADERC_TOOL_OUTPUT_BINARY}
+        COMMAND ${CMAKE_COMMAND} -E copy "${shaderc_prebuilt_SOURCE_DIR}/${SHADERC_TOOL_NAME}" ${SHADERC_TOOL_OUTPUT_BINARY}
+    )
+else()
+    add_custom_command(
+        OUTPUT ${SHADERC_TOOL_OUTPUT_BINARY}
+        COMMAND ${SHADERC_TOOL_BUILD_SCRIPT}
+        WORKING_DIRECTORY ${SHADERC_TOOL_WORKING_DIR}
+    )
+endif()
 
 add_custom_target(shaderc
     DEPENDS ${SHADERC_TOOL_OUTPUT_BINARY}


### PR DESCRIPTION
Since compiling `shaderc` from source takes quite a bit of time (mainly due to [glsl-optimizer](https://github.com/bkaradzic/bgfx/tree/f26fbaf1b817e9bc06082befdb1d5663602f7f59/3rdparty/glsl-optimizer)), I'm adding an option to fetch prebuilt binaries from [starter-tools](https://github.com/fiserj/starter-tools) repo, which I plan to use for these kinds of tools (if there ever are more), to not pollute the main repo with binary files.